### PR TITLE
warranty_end to string

### DIFF
--- a/lib/facter/dell_info.rb
+++ b/lib/facter/dell_info.rb
@@ -157,7 +157,7 @@ if Facter.value('manufacturer')
         end
         Facter.add(:warranty_end) do
           setcode do
-            warranty_end
+            warranty_end.to_s
           end
         end
       rescue Exception=>e


### PR DESCRIPTION
setcode doesn't like when warranty_end is a date value. Setting it to string eliminates these errors:

`Fact resolution fact='warranty_end', resolution='<anonymous>' resolved to an invalid value: Expected 2011-07-14 to be one of [Integer, Float, TrueClass, FalseClass, NilClass, String, Array, Hash], but was Date`